### PR TITLE
Add "-e rawout" to "play" a file to an OPL2/3 .RAW file

### DIFF
--- a/src/adplay.cc
+++ b/src/adplay.cc
@@ -27,6 +27,7 @@
 #include <adplug/kemuopl.h>
 #include <adplug/wemuopl.h>
 #include <adplug/nemuopl.h>
+#include <adplug/diskopl.h>
 #include <adplug/surroundopl.h>
 
 /*
@@ -64,7 +65,7 @@
 
 /***** Typedefs *****/
 
-typedef enum { Emu_Satoh, Emu_Ken, Emu_Woody, Emu_Nuked } EmuType;
+typedef enum { Emu_Satoh, Emu_Ken, Emu_Woody, Emu_Nuked, Emu_Rawout } EmuType;
 
 /***** Global variables *****/
 
@@ -158,7 +159,7 @@ static void usage()
 	 program_name);
 
   // Print list of available output mechanisms
-  printf("Available emulators: satoh ken woody nuked\n");
+  printf("Available emulators: satoh ken woody nuked rawout\n");
   printf("Available output mechanisms: "
 #ifdef DRIVER_OSS
 	 "oss "
@@ -262,6 +263,12 @@ static int decode_switches(int argc, char **argv)
 	else if(!strcmp(optarg, "ken")) cfg.emutype = Emu_Ken;
 	else if(!strcmp(optarg, "woody")) cfg.emutype = Emu_Woody;
 	else if(!strcmp(optarg, "nuked")) cfg.emutype = Emu_Nuked;
+  else if(!strcmp(optarg, "rawout")) {
+    cfg.emutype = Emu_Rawout;
+    cfg.output = null;
+    cfg.endless = false;
+  }
+
 	else {
 	  message(MSG_ERROR, "unknown emulator -- %s", optarg);
 	  exit(EXIT_FAILURE);
@@ -453,6 +460,8 @@ int main(int argc, char **argv)
   		}
   	}
   	break;
+  case Emu_Rawout:
+    opl = new CDiskopl(cfg.device);
   }
 
   // init player
@@ -468,7 +477,7 @@ int main(int argc, char **argv)
 #endif
 #ifdef DRIVER_NULL
   case null:
-    player = new NullOutput();
+    player = new NullOutput(opl);
     break;
 #endif
 #ifdef DRIVER_DISK

--- a/src/null.h
+++ b/src/null.h
@@ -20,20 +20,29 @@
 #ifndef H_NULL
 #define H_NULL
 
-#include <adplug/silentopl.h>
 #include "output.h"
 
 class NullOutput: public Player
 {
 public:
-  virtual void frame()
-    { }
+  NullOutput(Copl *nopl)
+    :opl(nopl)
+  { }
+
+  virtual void frame() {
+    playing = p->update();
+    
+    CDiskopl *dopl = dynamic_cast<CDiskopl *>(opl);
+    if (dopl != NULL) {
+      dopl->update(p);
+    }
+  }
 
   virtual Copl *get_opl()
-    { return &opl; }
+    { return opl; }
 
 private:
-  CSilentopl opl;
+  Copl *opl;
 };
 
 #endif

--- a/src/output.cc
+++ b/src/output.cc
@@ -20,6 +20,7 @@
 #include <stdio.h>
 #include <adplug/emuopl.h>
 #include <adplug/kemuopl.h>
+#include <adplug/diskopl.h>
 
 #include "output.h"
 #include "defines.h"
@@ -72,6 +73,11 @@ void EmuPlayer::frame()
     }
     i = min(towrite, (long)(minicnt / p->getrefresh() + 4) & ~3);
     opl->update((short *)pos, i);
+    CDiskopl *dopl = dynamic_cast<CDiskopl *>(opl);
+    if (dopl != NULL) {
+      dopl->update(p);
+    }
+
     pos += i * getsampsize(); towrite -= i;
     i = (long)(p->getrefresh() * i);
     minicnt -= max(1, i);


### PR DESCRIPTION
I'm not really a C++ dev, and I'm sure that this could really use some refactoring, but it works.

The idea is to allow someone to do `adplay -e rawout -d song.raw song.rad` to convert a song in some module format to the RDOS RAW format using adplug's "disk OPL" class. gamemus can then convert the RAW to formats like DRO, IMF, or VGM. `-e rawout` implies `-O null -o` since those are the options you probably want for conversion.

As part of the change, the null output driver now parses the input (calls `p->update()`) instead of ignoring the input and going to a non-playing state immediately.

The stuff I did with `dynamic_cast` is probably a bad idea, but I didn't see a better way without changing the interface of `Copl`, which I didn't want to take on.