### PR TITLE
Create adplug.desktop

### DIFF
--- a/adplug.desktop
+++ b/adplug.desktop
@@ -1,0 +1,10 @@
+[Desktop Entry]
+Name=adplug
+Comment=adlib sound player
+Exec=adplug %f
+Icon=adplug
+Terminal=true
+Type=Application
+Categories=AudioVideo;AudioVideoEditing
+Keywords=music;playing;
+MimeTypes=audio/a2m;audio/adl;audio/amd;audio/cff;audio/cmf;audio/d00;audio/dtm;audio/hsc;audio/hsp;audio/laa;audio/lds;audio/rad;audio/raw;audio/sa2;audio/sng;audio/xad;audio/xms;audio/xsm;


### PR DESCRIPTION
allows associationg adlib files in nautilus/files with whatever extension and playing them in terminal. it would be nice to have an icon for the desktop file. installation should go into /usr/share/applications/ (icon goes to /usr/share/icons/)