### PR TITLE
Add loop count option

### DIFF
--- a/doc/adplay.1
+++ b/doc/adplay.1
@@ -149,8 +149,14 @@ Play subsong number N, instead of the default subsong of the
 file. Only useful for file formats that support multiple subsongs.
 .TP
 .B -o --once
-Play just once, don't loop. This will exit \fBadplay\fP after the song
+Don't loop endlessly. This will exit \fBadplay\fP after the song
 ended. This is the default when multiple \fBFILEs\fP are given.
+.TP
+.B -l --loop=N
+Loop N times then stop. Due to technical limitations of the adplug library,
+a "loop" is considered to be the time between the start of playback and when
+looping first occurs. Accordingly, playback may actually halt at an unexpected
+point, especially when combined with \fB-s\fR. This implies \fB-o\fR.
 .SS "Miscellaneous:"
 .TP
 .B -D, --database=FILE


### PR DESCRIPTION
This adds the ability to specify a "loop count". Because the library appears to expose looping as a "once set, never cleared" flag, the only way I could figure out to count loops was to take the number of samples until the "has looped" flag becomes set as the loop length. Accordingly, using both `-l` and `-s` will probably not work "correctly". However, this is much better than nothing.

See also #8.