### PR TITLE
Rename min/max macros to uppercase to fix conflict with `std` namespace

### DIFF
--- a/src/defines.h
+++ b/src/defines.h
@@ -34,11 +34,11 @@
 #define MSG_NOTE	3
 #define MSG_DEBUG	4
 
-#ifndef min
-#  define min(a,b) (((a) < (b)) ? (a) : (b))
+#ifndef MIN
+#  define MIN(a,b) (((a) < (b)) ? (a) : (b))
 #endif
-#ifndef max
-#  define max(a,b) (((a) > (b)) ? (a) : (b))
+#ifndef MAX
+#  define MAX(a,b) (((a) > (b)) ? (a) : (b))
 #endif
 
 /***** Global functions *****/

--- a/src/output.cc
+++ b/src/output.cc
@@ -70,11 +70,11 @@ void EmuPlayer::frame()
       minicnt += freq;
       playing = p->update();
     }
-    i = min(towrite, (long)(minicnt / p->getrefresh() + 4) & ~3);
+    i = MIN(towrite, (long)(minicnt / p->getrefresh() + 4) & ~3);
     opl->update((short *)pos, i);
     pos += i * getsampsize(); towrite -= i;
     i = (long)(p->getrefresh() * i);
-    minicnt -= max(1, i);
+    minicnt -= MAX(1, i);
   }
 
   // call output driver

--- a/src/sdl.cc
+++ b/src/sdl.cc
@@ -75,7 +75,7 @@ void SDLPlayer::callback(void *userdata, Uint8 *audiobuf, int len)
       minicnt += self->spec.freq;
       self->playing = self->p->update();
     }
-    i = min(towrite, (long)(minicnt / self->p->getrefresh() + 4) & ~3);
+    i = MIN(towrite, (long)(minicnt / self->p->getrefresh() + 4) & ~3);
     self->opl->update((short *)pos, i);
     pos += i * self->getsampsize(); towrite -= i;
     minicnt -= (long)(self->p->getrefresh() * i);


### PR DESCRIPTION
Defining min/max in lowercase and then #including stdlib--that already implements std::min and std::max--causes many compilation errors, a sample of which I quote below:

```
make[1]: Entering directory '/home/danb/abs/adplay/src/adplay-1.8.1/src'
make  all-am
make[2]: Entering directory '/home/danb/abs/adplay/src/adplay-1.8.1/src'
g++ -DHAVE_CONFIG_H -I.  -I/usr/include/libbinio   -I/usr/include/SDL -D_GNU_SOURCE=1 -D_REENTRANT -DADPLUG_DATA_DIR=\"/usr/local/com/adplug\"   -g -O2 -MT esound.o -MD -MP -MF .deps/esound.Tpo -c -o esound.o esound.cc
In file included from /usr/include/c++/12.2.0/string:50,
                 from /usr/include/adplug/player.h:25,
                 from output.h:23,
                 from esound.h:23,
                 from esound.cc:25:
/usr/include/c++/12.2.0/bits/stl_algobase.h:278:56: error: macro "min" passed 3 arguments, but takes just 2
  278 |     min(const _Tp& __a, const _Tp& __b, _Compare __comp)
      |                                                        ^
In file included from esound.cc:24:
defines.h:38: note: macro "min" defined here
   38 | #  define min(a,b) (((a) < (b)) ? (a) : (b))
      |
/usr/include/c++/12.2.0/bits/stl_algobase.h:300:56: error: macro "max" passed 3 arguments, but takes just 2
  300 |     max(const _Tp& __a, const _Tp& __b, _Compare __comp)
      |                                                        ^
defines.h:41: note: macro "max" defined here
   41 | #  define max(a,b) (((a) > (b)) ? (a) : (b))
```

This didn't use to be a problem because apparently std::min and max were added only in 2011, but this code was written prior to that.