### PR TITLE
Mingw32 4.8.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ m4/lt~obsolete.m4
 src/adplay
 src/config.h*
 src/.libs/
+*.exe

--- a/configure.ac
+++ b/configure.ac
@@ -196,6 +196,9 @@ if test ${enable_output_sdl:=yes} = yes; then
      )
      AC_LANG_POP(C)
    fi
+  dnl strip away options that would turn our application from console to a windows GUI application
+  SDL_CFLAGS=`echo $SDL_CFLAGS |sed 's/-Dmain=SDL_main//g'`
+  SDL_LIBS=`echo $SDL_LIBS | sed 's/-mwindows/-mconsole/g' 's/-lSDLmain//g' 's/-lSDL2main//g'`
 fi
 
 # ALSA output

--- a/configure.ac
+++ b/configure.ac
@@ -197,8 +197,8 @@ if test ${enable_output_sdl:=yes} = yes; then
      AC_LANG_POP(C)
    fi
   dnl strip away options that would turn our application from console to a windows GUI application
-  SDL_CFLAGS=`echo $SDL_CFLAGS |sed 's/-Dmain=SDL_main//g'`
-  SDL_LIBS=`echo $SDL_LIBS | sed 's/-mwindows/-mconsole/g' 's/-lSDLmain//g' 's/-lSDL2main//g'`
+  SDL_CFLAGS=`echo $SDL_CFLAGS |sed -e 's/-Dmain=SDL_main//g'`
+  SDL_LIBS=`echo $SDL_LIBS | sed -e 's/-mwindows/-mconsole/g' -e 's/-lSDLmain//g' -e 's/-lSDL2main//g'`
 fi
 
 # ALSA output

--- a/src/getopt.h
+++ b/src/getopt.h
@@ -27,6 +27,10 @@
 extern "C" {
 #endif
 
+// in mingw, __argc and __argv are special
+#undef __argc
+#undef __argv
+
 /* For communication from `getopt' to the caller.
    When `getopt' finds an option that takes an argument,
    the argument value is returned here.

--- a/src/sdl.cc
+++ b/src/sdl.cc
@@ -17,6 +17,8 @@
  * Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.  
  */
 
+#include <stdlib.h>
+#include <string.h>
 #include <unistd.h>
 
 #include "sdl_driver.h"

--- a/src/sdl_driver.h
+++ b/src/sdl_driver.h
@@ -20,6 +20,8 @@
 #ifndef H_SDL
 #define H_SDL
 
+#define SDL_MAIN_HANDLED 1
+
 #include <SDL.h>
 
 #include "output.h"


### PR DESCRIPTION
Here's a PR for windows-specific modifications.
1) Renamed local sdl.h -> sdlx.h to avoid confusion #include "sdl.h" vs #include <SDL.h>
2) Added `sdl-win-fix.sh` script which fixes resulting Makefiles for compiling console application instead of windows one.
3) Smaller header fixes for SDL2

And yes, both compiling against old SDL12 and newer SDL2 is working (--with-sdl=sdl12 or --with-sdl=sdl2 configure flags)

`./configure --prefix=/mingw CXXFLAGS=-fpermissive`

Also, a bit ugly, but I had to add `#undef main` just before main(), because SDL on windows does `#define main SDLmain` somewhere inside its headers and it can't be overriden in mingw command line. This #undef does no harm on other platforms, though.