### PR TITLE
adplay: remove obsolete Apple workaround

### DIFF
--- a/src/adplay.cc
+++ b/src/adplay.cc
@@ -28,10 +28,10 @@
 #include <adplug/wemuopl.h>
 
 /*
- * Apple (OS X) and Sun systems declare getopt in unistd.h, other systems
- * (Linux) use getopt.h.
+ * Sun systems declare getopt in unistd.h,
+ * other systems (Linux, Apple) use getopt.h.
  */
-#if defined (__APPLE__) || (defined(__SVR4) && defined(__sun))
+#if (defined(__SVR4) && defined(__sun))
 #	include <unistd.h>
 #else
 #	ifdef HAVE_GETOPT_H


### PR DESCRIPTION
This check dates to pretty early - I found it in 28e62ed68c5d23605edd73c4267789b2af0b5c09, from 2004. I checked, and this was only true in OS X 10.0 through 10.2. With the [version of libc](https://github.com/apple-oss-distributions/Libc/commit/bf35f81f8e712c9640fb1b0aed280b1b9c752aaf) available in OS X 10.3 and newer, `getopt.h` exists like on Linux and has to be included to get what adplay expects to be there. I'm guessing there's a good chance adplay won't compile on OS X 10.0 through 10.2 these days anyway.

This and #28 got adplay-unix building for me on current versions of macOS.