### PR TITLE
Initialize userdb to NULL.

### DIFF
--- a/src/adplay.cc
+++ b/src/adplay.cc
@@ -425,7 +425,7 @@ int main(int argc, char **argv)
 {
   int			optind, i;
   const char		*homedir;
-  char			*userdb;
+  char			*userdb = NULL;
 
   // init
   program_name = argv[0];


### PR DESCRIPTION
Needed if $HOME is not defined, can happen when using WINE.