### PR TITLE
Update autoconf m4 macros, removing warnings about obsolete macros

### DIFF
--- a/m4/ao.m4
+++ b/m4/ao.m4
@@ -2,6 +2,7 @@
 # Configure paths for libao
 # Jack Moffitt <jack@icecast.org> 10-21-2000
 # Shamelessly stolen from Owen Taylor and Manish Singh
+# AdPlay/Unix updated some usage of deprecated macros
 
 dnl XIPH_PATH_AO([ACTION-IF-FOUND [, ACTION-IF-NOT-FOUND]])
 dnl Test for libao, and define AO_CFLAGS and AO_LIBS

--- a/m4/ao.m4
+++ b/m4/ao.m4
@@ -47,17 +47,18 @@ dnl
 dnl Now check if the installed ao is sufficiently new.
 dnl
       rm -f conf.aotest
-      AC_TRY_RUN([
+      AC_RUN_IFELSE([AC_LANG_PROGRAM([[
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <ao/ao.h>
+]],[[
 int main ()
 {
   system("touch conf.aotest");
   return 0;
 }
-],, no_ao=yes,[echo $ac_n "cross compiling; assumed OK... $ac_c"])
+]])],, no_ao=yes,[echo $ac_n "cross compiling; assumed OK... $ac_c"])
        CFLAGS="$ac_save_CFLAGS"
        LIBS="$ac_save_LIBS"
   fi
@@ -72,10 +73,10 @@ int main ()
        echo "*** Could not run ao test program, checking why..."
        CFLAGS="$CFLAGS $AO_CFLAGS"
        LIBS="$LIBS $AO_LIBS"
-       AC_TRY_LINK([
+       AC_LINK_IFELSE([AC_LANG_PROGRAM([[
 #include <stdio.h>
 #include <ao/ao.h>
-],     [ return 0; ],
+]],[[ return 0; ]])],
        [ echo "*** The test program compiled, but did not run. This usually means"
        echo "*** that the run-time linker is not finding ao or finding the wrong"
        echo "*** version of ao. If it is not finding ao, you'll need to set your"

--- a/m4/esd.m4
+++ b/m4/esd.m4
@@ -39,7 +39,7 @@ AC_ARG_ENABLE(esdtest, [  --disable-esdtest       Do not try to compile and run 
     no_esd=yes
   else
     AC_LANG_SAVE
-    AC_LANG_C
+    AC_LANG([C])
     ESD_CFLAGS=`$ESD_CONFIG $esdconf_args --cflags`
     ESD_LIBS=`$ESD_CONFIG $esdconf_args --libs`
 
@@ -59,12 +59,12 @@ dnl Now check if the installed ESD is sufficiently new. (Also sanity
 dnl checks the results of esd-config to some extent
 dnl
       rm -f conf.esdtest
-      AC_TRY_RUN([
+      AC_RUN_IFELSE([AC_LANG_PROGRAM([[
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <esd.h>
-
+]],[[
 char*
 my_strdup (char *str)
 {
@@ -113,7 +113,7 @@ int main ()
     }
 }
 
-],, no_esd=yes,[echo $ac_n "cross compiling; assumed OK... $ac_c"])
+]])],, no_esd=yes,[echo $ac_n "cross compiling; assumed OK... $ac_c"])
        CFLAGS="$ac_save_CFLAGS"
        LIBS="$ac_save_LIBS"
        AC_LANG_RESTORE
@@ -137,11 +137,11 @@ int main ()
           CFLAGS="$CFLAGS $ESD_CFLAGS"
           LIBS="$LIBS $ESD_LIBS"
           AC_LANG_SAVE
-          AC_LANG_C
-          AC_TRY_LINK([
+          AC_LANG([C])
+          AC_LINK_IFELSE([AC_LANG_PROGRAM([[
 #include <stdio.h>
 #include <esd.h>
-],      [ return 0; ],
+]],[[ return 0; ]])],
         [ echo "*** The test program compiled, but did not run. This usually means"
           echo "*** that the run-time linker is not finding ESD or finding the wrong"
           echo "*** version of ESD. If it is not finding ESD, you'll need to set your"

--- a/m4/esd.m4
+++ b/m4/esd.m4
@@ -3,6 +3,7 @@
 # stolen back from Frank Belew
 # stolen from Manish Singh
 # Shamelessly stolen from Owen Taylor
+# AdPlay/Unix updated some usage of deprecated macros
 
 dnl AM_PATH_ESD([MINIMUM-VERSION, [ACTION-IF-FOUND [, ACTION-IF-NOT-FOUND]]])
 dnl Test for ESD, and define ESD_CFLAGS and ESD_LIBS


### PR DESCRIPTION
ESD upstream is dead
libao upstream maybe is alive?