### PR TITLE
Initialize ao format members to zero. Without this, matrix can point to random data.

### DIFF
--- a/src/ao.cc
+++ b/src/ao.cc
@@ -33,7 +33,7 @@ AOPlayer::AOPlayer(Copl *nopl, const char *device, unsigned char bits,
 		     int channels, int freq, unsigned long bufsize)
   : EmuPlayer(nopl, bits, channels, freq, bufsize)
 {
-	ao_sample_format format;
+	ao_sample_format format = {0};
 	int default_driver;
 
 	ao_initialize();


### PR DESCRIPTION
Should fix #16 